### PR TITLE
feat: add shared Maze event properties

### DIFF
--- a/src/main/java/tech/maze/commons/CommonsConfiguration.java
+++ b/src/main/java/tech/maze/commons/CommonsConfiguration.java
@@ -1,6 +1,7 @@
 package tech.maze.commons;
 
 import lombok.NoArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,6 +12,7 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 @ComponentScan("tech.maze.commons")
+@ConfigurationPropertiesScan("tech.maze.commons")
 @NoArgsConstructor
 public class CommonsConfiguration {
 

--- a/src/main/java/tech/maze/commons/eventstream/MazeEventProperties.java
+++ b/src/main/java/tech/maze/commons/eventstream/MazeEventProperties.java
@@ -13,9 +13,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Data
 @FieldDefaults(level = AccessLevel.PRIVATE)
 @ConfigurationProperties(prefix = MazeEventProperties.PREFIX)
-@ConditionalOnProperty(prefix = MazeEventProperties.PREFIX, name = "source")
+@ConditionalOnProperty(prefix = MazeEventProperties.PREFIX, name = "enabled", havingValue = "true")
 public class MazeEventProperties {
   public static final String PREFIX = "maze.events";
+
+  /**
+   * Enables event streaming configuration.
+   */
+  boolean enabled;
 
   /**
    * CloudEvents source for events emitted by this service.

--- a/src/main/java/tech/maze/commons/eventstream/MazeEventProperties.java
+++ b/src/main/java/tech/maze/commons/eventstream/MazeEventProperties.java
@@ -1,0 +1,24 @@
+package tech.maze.commons.eventstream;
+
+import java.net.URI;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for Maze event streaming.
+ */
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@ConfigurationProperties(prefix = MazeEventProperties.PREFIX)
+@ConditionalOnProperty(prefix = MazeEventProperties.PREFIX, name = "source")
+public class MazeEventProperties {
+  public static final String PREFIX = "maze.events";
+
+  /**
+   * CloudEvents source for events emitted by this service.
+   */
+  URI source;
+}


### PR DESCRIPTION
## Summary\n- add shared  with  binding\n- enable configuration properties scanning in commons\n\n## Testing\n- not run (CI only)