### PR TITLE
Harden build-scan latest release lookup

### DIFF
--- a/.github/workflows/build-scan.yaml
+++ b/.github/workflows/build-scan.yaml
@@ -137,9 +137,11 @@ jobs:
         id: get_latest_version
         if: github.event_name == 'pull_request'
         run: |
-          # Get the latest release tag
-          LATEST_TAG=$(gh api repos/${{ github.repository }}/releases/latest --jq '.tag_name' 2>/dev/null || echo "")
-          if [ -z "$LATEST_TAG" ]; then
+          # Get the latest release tag (empty when no release exists)
+          LATEST_TAG=$(gh api repos/${{ github.repository }}/releases/latest --jq '.tag_name // empty' 2>/dev/null || true)
+
+          # Defensive guard: ignore non-tag payloads
+          if [ -z "$LATEST_TAG" ] || [[ "$LATEST_TAG" == *"Not Found"* ]] || [[ "$LATEST_TAG" == "{"* ]]; then
             echo "No published version found, skipping baseline comparison"
             echo "has_baseline=false" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## Summary
- use robust release lookup ()
- guard against non-tag payloads before baseline download
- prevent false failures when no release exists yet
