### PR TITLE
Add shared GrpcStatusException handler

### DIFF
--- a/src/main/java/tech/maze/commons/configuration/GrpcExceptionConfiguration.java
+++ b/src/main/java/tech/maze/commons/configuration/GrpcExceptionConfiguration.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.grpc.server.exception.GrpcExceptionHandler;
+import tech.maze.commons.exceptions.GrpcStatusException;
 
 /**
  * Configuration class for gRPC exception handling.
@@ -32,13 +33,30 @@ public class GrpcExceptionConfiguration {
   }
 
   /**
+   * Handles GrpcStatusException and returns the embedded status and message.
+   *
+   * @param e The GrpcStatusException that was thrown
+   * @return A StatusException with mapped status containing the error message
+   */
+  @Bean
+  @Order(2)
+  GrpcExceptionHandler grpcStatusExceptionHandler() {
+    return e -> (e instanceof GrpcStatusException ex)
+      ? ex.status()
+      .withDescription(ex.getMessage())
+      .withCause(e)
+      .asException()
+      : null;
+  }
+
+  /**
    * Handles IllegalArgumentException and converts it to a gRPC INVALID_ARGUMENT status.
    *
    * @param e The IllegalArgumentException that was thrown
    * @return A StatusException with INVALID_ARGUMENT status containing the error message
    */
   @Bean
-  @Order(2)
+  @Order(3)
   GrpcExceptionHandler illegalArgumentExceptionHandler() {
     return e -> (e instanceof IllegalArgumentException)
       ? Status.INVALID_ARGUMENT

--- a/src/main/java/tech/maze/commons/exceptions/GrpcStatusException.java
+++ b/src/main/java/tech/maze/commons/exceptions/GrpcStatusException.java
@@ -1,0 +1,50 @@
+package tech.maze.commons.exceptions;
+
+import io.grpc.Status;
+
+/**
+ * Runtime exception carrying an explicit gRPC status to return to clients.
+ */
+public class GrpcStatusException extends RuntimeException {
+  private final Status status;
+
+  /**
+   * Creates a status-aware runtime exception.
+   *
+   * @param status gRPC status to return
+   * @param message error description to expose
+   */
+  public GrpcStatusException(Status status, String message) {
+    super(message);
+    this.status = status;
+  }
+
+  /**
+   * Returns the mapped gRPC status.
+   *
+   * @return gRPC status
+   */
+  public Status status() {
+    return status;
+  }
+
+  /**
+   * Factory for INVALID_ARGUMENT errors.
+   *
+   * @param message error description
+   * @return status-aware exception
+   */
+  public static GrpcStatusException invalidArgument(String message) {
+    return new GrpcStatusException(Status.INVALID_ARGUMENT, message);
+  }
+
+  /**
+   * Factory for NOT_FOUND errors.
+   *
+   * @param message error description
+   * @return status-aware exception
+   */
+  public static GrpcStatusException notFound(String message) {
+    return new GrpcStatusException(Status.NOT_FOUND, message);
+  }
+}

--- a/src/test/java/tech/maze/commons/configuration/GrpcExceptionConfigurationTest.java
+++ b/src/test/java/tech/maze/commons/configuration/GrpcExceptionConfigurationTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.grpc.server.exception.GrpcExceptionHandler;
+import tech.maze.commons.exceptions.GrpcStatusException;
 
 /**
  * Unit tests for the GrpcExceptionConfiguration class.
@@ -75,6 +76,54 @@ class GrpcExceptionConfigurationTest {
     final StatusException result = invokeHandler(handler, exception);
 
     // Assert
+    assertNull(result);
+  }
+
+  @Test
+  @DisplayName("Should create grpcStatusExceptionHandler bean successfully")
+  void shouldCreateGrpcStatusExceptionHandler() {
+    final GrpcExceptionHandler handler = configuration.grpcStatusExceptionHandler();
+    assertNotNull(handler);
+  }
+
+  @Test
+  @DisplayName("Should handle GrpcStatusException INVALID_ARGUMENT")
+  void shouldHandleGrpcStatusExceptionInvalidArgument() throws Exception {
+    final String errorMessage = "Invalid request payload";
+    final GrpcStatusException exception = GrpcStatusException.invalidArgument(errorMessage);
+    final GrpcExceptionHandler handler = configuration.grpcStatusExceptionHandler();
+
+    final StatusException result = invokeHandler(handler, exception);
+
+    assertNotNull(result);
+    assertEquals(Status.Code.INVALID_ARGUMENT, result.getStatus().getCode());
+    assertEquals(errorMessage, result.getStatus().getDescription());
+    assertEquals(exception, result.getCause());
+  }
+
+  @Test
+  @DisplayName("Should handle GrpcStatusException NOT_FOUND")
+  void shouldHandleGrpcStatusExceptionNotFound() throws Exception {
+    final String errorMessage = "Asset not found";
+    final GrpcStatusException exception = GrpcStatusException.notFound(errorMessage);
+    final GrpcExceptionHandler handler = configuration.grpcStatusExceptionHandler();
+
+    final StatusException result = invokeHandler(handler, exception);
+
+    assertNotNull(result);
+    assertEquals(Status.Code.NOT_FOUND, result.getStatus().getCode());
+    assertEquals(errorMessage, result.getStatus().getDescription());
+    assertEquals(exception, result.getCause());
+  }
+
+  @Test
+  @DisplayName("Should return null for non-GrpcStatusException")
+  void shouldReturnNullForNonGrpcStatusException() throws Exception {
+    final RuntimeException exception = new RuntimeException("Not a grpc status exception");
+    final GrpcExceptionHandler handler = configuration.grpcStatusExceptionHandler();
+
+    final StatusException result = invokeHandler(handler, exception);
+
     assertNull(result);
   }
 
@@ -228,4 +277,3 @@ class GrpcExceptionConfigurationTest {
     return (StatusException) handlerMethod.invoke(handler, exception);
   }
 }
-


### PR DESCRIPTION
## Summary
- add  in commons to carry explicit gRPC status + message
- add  in 
- keep  handler as fallback
- add/adjust unit tests for new handler behavior

## Why
- avoid overloading generic 
- allow microservices to throw one runtime exception type while controlling gRPC status mapping centrally