### PR TITLE
Add shared pagination models and utils in commons

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,6 +108,13 @@ dependencies {
   testImplementation "com.h2database:h2:$h2Version"
 }
 
+processResources {
+  from("src/main/smithy") {
+    include("**/*.smithy")
+    into("META-INF/smithy")
+  }
+}
+
 checkstyle {
   toolVersion = "13.2.0"
   config = resources.text.fromFile("$rootDir/config/checkstyle/checkstyle.xml")

--- a/src/main/java/tech/maze/commons/pagination/Pagination.java
+++ b/src/main/java/tech/maze/commons/pagination/Pagination.java
@@ -1,0 +1,9 @@
+package tech.maze.commons.pagination;
+
+/**
+ * Normalized pagination bounds for repository queries.
+ */
+public record Pagination(
+    int page,
+    int limit
+) {}

--- a/src/main/java/tech/maze/commons/pagination/PaginationUtils.java
+++ b/src/main/java/tech/maze/commons/pagination/PaginationUtils.java
@@ -1,0 +1,30 @@
+package tech.maze.commons.pagination;
+
+/**
+ * Helpers to normalize pagination inputs from external requests.
+ */
+public final class PaginationUtils {
+  private PaginationUtils() {}
+
+  /**
+   * Normalizes raw pagination values and clamps them to int bounds.
+   *
+   * @param page requested page (0-based)
+   * @param limit requested page size
+   * @param defaultLimit fallback limit when input is invalid
+   * @return normalized pagination values
+   */
+  public static Pagination normalize(long page, long limit, int defaultLimit) {
+    final long sanitizedPage = Math.max(0L, page);
+    final long sanitizedLimit = Math.max(1L, limit > 0 ? limit : defaultLimit);
+
+    return new Pagination(
+        longToIntClamped(sanitizedPage),
+        longToIntClamped(sanitizedLimit)
+    );
+  }
+
+  private static int longToIntClamped(long value) {
+    return value > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) value;
+  }
+}

--- a/src/main/resources/META-INF/smithy/manifest
+++ b/src/main/resources/META-INF/smithy/manifest
@@ -1,0 +1,3 @@
+tech/maze/dtos/commons/math/big-decimal.smithy
+tech/maze/dtos/commons/math/big-integer.smithy
+tech/maze/dtos/commons/search/pagination.smithy

--- a/src/main/smithy/tech/maze/dtos/commons/search/pagination.smithy
+++ b/src/main/smithy/tech/maze/dtos/commons/search/pagination.smithy
@@ -1,0 +1,17 @@
+$version: "2"
+
+namespace tech.maze.dtos.commons.search
+
+use alloy.proto#protoEnabled
+
+@protoEnabled
+structure Pagination {
+    page: Long
+    limit: Long
+}
+
+@protoEnabled
+structure PaginationInfos {
+    totalElements: Long
+    totalPages: Long
+}

--- a/src/test/java/tech/maze/commons/pagination/PaginationUtilsTest.java
+++ b/src/test/java/tech/maze/commons/pagination/PaginationUtilsTest.java
@@ -1,0 +1,44 @@
+package tech.maze.commons.pagination;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PaginationUtilsTest {
+  @Test
+  @DisplayName("Should normalize valid pagination values")
+  void shouldNormalizeValidPaginationValues() {
+    final Pagination pagination = PaginationUtils.normalize(2L, 25L, 50);
+
+    assertEquals(2, pagination.page());
+    assertEquals(25, pagination.limit());
+  }
+
+  @Test
+  @DisplayName("Should normalize negative page and zero limit")
+  void shouldNormalizeNegativePageAndZeroLimit() {
+    final Pagination pagination = PaginationUtils.normalize(-5L, 0L, 50);
+
+    assertEquals(0, pagination.page());
+    assertEquals(50, pagination.limit());
+  }
+
+  @Test
+  @DisplayName("Should fallback to minimum limit when defaultLimit is invalid")
+  void shouldFallbackToMinimumLimitWhenDefaultLimitIsInvalid() {
+    final Pagination pagination = PaginationUtils.normalize(1L, 0L, 0);
+
+    assertEquals(1, pagination.page());
+    assertEquals(1, pagination.limit());
+  }
+
+  @Test
+  @DisplayName("Should clamp very large values to Integer.MAX_VALUE")
+  void shouldClampVeryLargeValues() {
+    final Pagination pagination = PaginationUtils.normalize(Long.MAX_VALUE, Long.MAX_VALUE, 50);
+
+    assertEquals(Integer.MAX_VALUE, pagination.page());
+    assertEquals(Integer.MAX_VALUE, pagination.limit());
+  }
+}


### PR DESCRIPTION
## Summary
- add shared Smithy models in commons: `tech.maze.dtos.commons.search#Pagination` and `PaginationInfos`
- package commons Smithy models under `META-INF/smithy` with manifest
- add reusable Java pagination helper: `PaginationUtils.normalize(...)`
- add unit tests for pagination normalization

## Goal
Enable specs and microservices to reuse one pagination model and normalization logic instead of duplicating per service.