### PR TITLE
ci: run smithy format check on develop pushes

### DIFF
--- a/.github/workflows/smithy-fmt-check.yaml
+++ b/.github/workflows/smithy-fmt-check.yaml
@@ -5,6 +5,9 @@ on:
     types: [opened, reopened, synchronize]
     branches-ignore:
       - main
+  push:
+    branches:
+      - develop
 
 env:
   SMITHY_CLI_VERSION: '1.58.0'


### PR DESCRIPTION
Enable  status on develop commits so direct  fast-forward to main passes required checks.