### PR TITLE
fix(smithy): include duration model in manifest

### DIFF
--- a/src/main/resources/META-INF/smithy/manifest
+++ b/src/main/resources/META-INF/smithy/manifest
@@ -1,3 +1,4 @@
 tech/maze/dtos/commons/math/big-decimal.smithy
 tech/maze/dtos/commons/math/big-integer.smithy
 tech/maze/dtos/commons/search/pagination.smithy
+tech/maze/dtos/commons/time/duration.smithy


### PR DESCRIPTION
Fix commons smithy manifest so  is resolvable from released artifact.